### PR TITLE
fix ms-coff image output

### DIFF
--- a/peachpy/writer.py
+++ b/peachpy/writer.py
@@ -276,6 +276,9 @@ class MSCOFFWriter(ImageWriter):
         self.rdata_section = ReadOnlyDataSection()
         self.image.add_section(self.rdata_section)
 
+    def encode(self):
+        return self.image.encode()
+
     def add_function(self, function):
         import peachpy.x86_64.function
         assert isinstance(function, peachpy.x86_64.function.ABIFunction), \


### PR DESCRIPTION
`MSCOFFWriter` was generating 0-byte files due to missing `MSCOFFWriter.encode()` method.