### PR TITLE
fix intermitent unmmap EINVAL errno

### DIFF
--- a/peachpy/loader.py
+++ b/peachpy/loader.py
@@ -46,7 +46,7 @@ class Loader:
             munmap_function.argtype = [ctypes.c_void_p, ctypes.c_size_t]
 
             def munmap(address, size):
-                munmap_result = munmap_function(address, size)
+                munmap_result = munmap_function(ctypes.c_void_p(address), size)
                 assert munmap_result == 0
 
             self._release_memory = lambda address_size: munmap(address_size[0], address_size[1])


### PR DESCRIPTION
Depending on the address of the mapping on X86_64 debian jessie with python3, the unmmap can return -1 and set errno to EINVAL.
casting the address to ctypes.c_void solve the problem.

By the way what was the reason which made you switch from python mmap to ctypes functions ?
