### PR TITLE
missing ancestor for SHA isa extension

### DIFF
--- a/peachpy/x86_64/isa.py
+++ b/peachpy/x86_64/isa.py
@@ -106,6 +106,7 @@ class Extension:
             "PCLMULQDQ": (pclmulqdq,),
             "RDRAND": (rdrand,),
             "RDSEED": (rdrand, rdseed),
+            "SHA": (sha,),
             "AVX": (avx,),
             "F16C": (f16c,),
             "AVX2": (avx, avx2),


### PR DESCRIPTION
This was preventing using the SHA instructions. See #47 for a somewhat related issue.