### PR TITLE
Make PeachPy pip installable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ python:
   - "pypy"
   - "pypy3"
 install:
-  - pip install -r requirements.txt
-  - python setup.py generate
   - pip install .
   - pip install -r test/requirements.txt
   - export PATH="$HOME/.local/bin:$PATH"
-script: nosetests
+script:
+  - nosetests

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,8 @@ verbosity = 2
 where = ./test
 # Color output
 rednose = 1
+# --no-path-adjustment is required because we want to run the tests against
+# what is installed, not what is in the checked out source directory.
+# (Extra files are generated during installation which don't exist in the
+# source tree.)
+no-path-adjustment=1

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,26 @@
 #!/usr/bin/env python
 
-from peachpy import __version__
 import distutils.log
+from distutils.command.build import build
+from setuptools.command.develop import develop
 from distutils.cmd import Command
-from distutils.core import setup
-
+from setuptools import setup
 
 def read_text_file(path):
     import os
     with open(os.path.join(os.path.dirname(__file__), path)) as f:
         return f.read()
 
+
+class BuildGenerateInstructions(build):
+    def run(self):
+        self.run_command("generate")
+        build.run(self)
+
+class DevelopGenerateInstructions(develop):
+    def run(self):
+        self.run_command("generate")
+        develop.run(self)
 
 class GenerateInstructions(Command):
     description = "Generate Peach-Py instructions from Opcodes DB"
@@ -39,7 +49,7 @@ class GenerateInstructions(Command):
 
 setup(
     name="PeachPy",
-    version=__version__,
+    version="0.2.0",
     description="Portable Efficient Assembly Codegen in Higher-level Python",
     author="Marat Dukhan",
     author_email="maratek@gmail.com",
@@ -77,6 +87,10 @@ setup(
         "Topic :: Software Development :: Compilers",
         "Topic :: Software Development :: Libraries"
         ],
+    setup_requires=["Opcodes==0.3.10", "six"],
+    install_requires=["six", "enum34"],
     cmdclass={
-        "generate": GenerateInstructions
+        "build": BuildGenerateInstructions,
+        "develop": DevelopGenerateInstructions,
+        "generate": GenerateInstructions,
     })


### PR DESCRIPTION
This patch makes setuptools a dependency. This is needed to make
`setup.py` automatically make the `Opcodes` module available at setup
time.

Opcodes is made into a setup-time dependency, and if the module is
installed with `python setup.py build` or `python setup.py develop`
or `pip install PeachPy` or `pip install --editable PeachPy`, then
the `python setup.py generate` command is run automatically.

This patch depends on https://github.com/Maratyszcza/Opcodes/pull/5
because of the way setuptools handles setup-time dependencies. They are
not installed proper, but made available as an .egg file. Opcodes,
before Maratyszcza/Opcodes#5, tries to read the XML descriptions by
opening a file relative to `__file__`, which is not a thing which can
be read with `open()`. Instead, it has to use `pkg_resources` to do
so.

With these two PRs merged, it should be possible to `pip install
git+https://github.com/Maratyszcza/PeachPy`. We could also then discuss
making it easy to package up and upload to PyPi.