### PR TITLE
x86_64: fix register allocator (issue 65, min of empty list)

### DIFF
--- a/peachpy/common/regalloc.py
+++ b/peachpy/common/regalloc.py
@@ -61,9 +61,14 @@ class RegisterAllocator:
         return sum(1 for reg in self.allocation_options[virtual_id] if reg != physical_id)
 
     def _min_conflict_allocation_alternatives(self, virtual_id, physical_id):
-        return min(self._allocation_alternatives(-conflict_internal_id, physical_id)
-                   for conflict_internal_id in self.conflicting_registers[virtual_id]
-                   if conflict_internal_id < 0)
+        alternatives = [
+            self._allocation_alternatives(-conflict_internal_id, physical_id)
+            for conflict_internal_id in self.conflicting_registers[virtual_id]
+            if conflict_internal_id < 0
+        ]
+        if not alternatives:
+            return 0
+        return min(alternatives)
 
     def allocate_registers(self):
         unallocated_registers = [reg for reg in six.iterkeys(self.allocation_options)

--- a/test/x86_64/test_register_allocation.py
+++ b/test/x86_64/test_register_allocation.py
@@ -62,3 +62,39 @@ TEXT \xc2\xB7implicit_reg(SB),4,$0-8
 	RET
 """
         assert equal_codes(listing, ref_listing), "Unexpected PeachPy listing:\n" + listing
+
+
+class TestIssue65(unittest.TestCase):
+    def runTest(self):
+        with Function("crash", (), int64_t) as function:
+            r = GeneralPurposeRegister64()
+            MOV(r, 999)
+            RETURN(rax)
+
+        listing = function.finalize(abi.goasm_amd64_abi).format("go")
+        ref_listing = """
+// func crash() int64
+TEXT \xc2\xB7crash(SB),4,$0-8
+	MOVQ $999, BX
+	MOVQ AX, ret+0(FP)
+	RET
+"""
+        assert equal_codes(listing, ref_listing), "Unexpected PeachPy listing:\n" + listing
+
+class TestIssue65SecondComment(unittest.TestCase):
+    def runTest(self):
+        with Function("crash", (), int64_t) as function:
+            r = GeneralPurposeRegister64()
+            MOV(r, 1)
+            MOV(r, [rax])
+            RET()
+
+        listing = function.finalize(abi.goasm_amd64_abi).format("go")
+        ref_listing = """
+// func crash() int64
+TEXT \xc2\xB7crash(SB),4,$0-8
+MOVQ $1, BX
+MOVQ 0(AX), BX
+RET
+"""
+        assert equal_codes(listing, ref_listing), "Unexpected PeachPy listing:\n" + listing


### PR DESCRIPTION
I don't fully understand why #65 is broken, but here is an attempt at a fix.
Please check the sense of it carefully.

I'm pushing a test first so that it's easy to see that it fails without the fix.

Fixes #65.