### PR TITLE
x86_64: fix register allocator (misuse of filter)

### DIFF
--- a/peachpy/x86_64/function.py
+++ b/peachpy/x86_64/function.py
@@ -687,7 +687,8 @@ class Function:
                                              if reg_mask & instruction_register.mask != 0]
                     self._register_allocators[instruction_register.kind].add_conflicts(
                         instruction_register.virtual_id, conflict_internal_ids)
-            physical_registers = filter(lambda r: not r.is_virtual, instruction_registers)
+            physical_registers = [r for r in instruction_registers
+                                  if not r.is_virtual]
             if physical_registers:
                 from peachpy.x86_64.registers import Register
                 live_virtual_registers = \

--- a/test/x86_64/test_register_allocation.py
+++ b/test/x86_64/test_register_allocation.py
@@ -24,6 +24,32 @@ TEXT \xc2\xB7explicit_reg_input(SB),4,$0-8
         assert equal_codes(listing, ref_listing), "Unexpected PeachPy listing:\n" + listing
 
 
+class TestExplicitRegisterConflict2(unittest.TestCase):
+    def runTest(self):
+        with Function("explicit_reg_input_2", ()) as function:
+            g1 = GeneralPurposeRegister64()
+            g2 = GeneralPurposeRegister64()
+            MOV(g1, 0)
+            MOV(g2, 0)
+            MOV(rax, 0)
+            MOV([g1], 0)
+            MOV([g2], 0)
+            RET()
+
+        listing = function.finalize(abi.goasm_amd64_abi).format("go")
+        ref_listing = """
+// func explicit_reg_input_2()
+TEXT \xc2\xB7explicit_reg_input_2(SB),4,$0
+        MOVQ $0, BX
+        MOVQ $0, CX
+        MOVQ $0, AX
+        MOVB $0, 0(BX)
+        MOVB $0, 0(CX)
+        RET
+"""
+        assert equal_codes(listing, ref_listing), "Unexpected PeachPy listing:\n" + listing
+
+
 class TestExplicitRegisterOutputConflict(unittest.TestCase):
     def runTest(self):
         with Function("explicit_reg_output", (), uint64_t) as function:


### PR DESCRIPTION
On Python3, filter returns a lazy iterator which can be exhausted
exactly once. Unfortunately `physical_registers` was considered
multiple times, once for each virtual register. So if there was
more than one virtual register present, the register allocator
was not giving a sensible result.
    
See #63.