### PR TITLE
Fix #71: Make the address of LocalVariable settable

### DIFF
--- a/peachpy/x86_64/function.py
+++ b/peachpy/x86_64/function.py
@@ -1111,7 +1111,7 @@ class ABIFunction:
             from peachpy.util import roundup
             for local_variable in local_variables_list:
                 local_variable_address = roundup(local_variable_address, local_variable.alignment)
-                local_variable.address = local_variable_address
+                local_variable._address = local_variable_address
                 local_variable_address += local_variable.size
             self._local_variables_size = local_variable_address
 

--- a/test/x86_64/test_function.py
+++ b/test/x86_64/test_function.py
@@ -130,6 +130,40 @@ uint32_t integer_sum(uint32_t x, uint32_t y)
 """
         assert equal_codes(code, ref_code), "Unexpected PeachPy code:\n" + code
 
+class ComputeIntegerSumWithLocalVariable(unittest.TestCase):
+    def runTest(self):
+
+        x = Argument(uint32_t)
+        y = Argument(uint32_t)
+
+        with Function("integer_sum", (x, y), uint32_t) as function:
+            r_x = GeneralPurposeRegister32()
+            r_x_temp = GeneralPurposeRegister32()
+            r_y = GeneralPurposeRegister32()
+            buffer = LocalVariable(4)
+
+            LOAD.ARGUMENT(r_x, x)
+            LOAD.ARGUMENT(r_y, y)
+
+            MOV(buffer, r_x)
+            MOV(r_x_temp, buffer)
+
+            ADD(r_x_temp, r_y)
+            MOV(eax, r_x_temp)
+            RETURN()
+
+        code = function.format()
+        ref_code = """
+uint32_t integer_sum(uint32_t x, uint32_t y)
+    LOAD.ARGUMENT gp32-vreg<1>, uint32_t x
+    LOAD.ARGUMENT gp32-vreg<3>, uint32_t y
+    MOV dword [rsp], gp32-vreg<1>
+    MOV gp32-vreg<2>, dword [rsp]
+    ADD gp32-vreg<2>, gp32-vreg<3>
+    MOV eax, gp32-vreg<2>
+    RETURN
+"""
+        assert equal_codes(code, ref_code), "Unexpected PeachPy code:\n" + code
 
 class SimpleLoop(unittest.TestCase):
     def runTest(self):


### PR DESCRIPTION
Without this change, it doesn't appear to be possible to use LocalVariable
within a Function on x86_64 at all (see issue #71).

Reject setting the address of subvariables.