### PR TITLE
convert file to ascii encoding from utf-8 encoding 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -277,6 +277,6 @@ Acknowledgements
 
 This work is a research project at the HPC Garage lab in the Georgia Institute of Technology, College of Computing, School of Computational Science and Engineering.
 
-The work was supported in part by grants to Prof. Richard Vuduc’s research lab, `The HPC Garage <www.hpcgarage.org>`_, from the National Science Foundation (NSF) under NSF CAREER award number 0953100; and a grant from the Defense Advanced Research Projects Agency (DARPA) Computer Science Study Group program
+The work was supported in part by grants to Prof. Richard Vuduc's research lab, `The HPC Garage <www.hpcgarage.org>`_, from the National Science Foundation (NSF) under NSF CAREER award number 0953100; and a grant from the Defense Advanced Research Projects Agency (DARPA) Computer Science Study Group program
 
 Any opinions, conclusions or recommendations expressed in this software and documentation are those of the authors and not necessarily reflect those of NSF or DARPA.


### PR DESCRIPTION
When I'm trying to install PeachPy, it failed with info shown below:
Traceback (most recent call last):
  File "setup.py", line 61, in <module>
    long_description=read_text_file("README.rst"),
  File "setup.py", line 12, in read_text_file
    return f.read()
  File "/root/SkyDiscovery/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 12652: ordinal not in range(128)

Then, I found that the single quote in README.rst in position 12652 is not ascii single quote. 
By the way, in my case, python's version is 3.5.2 and pip's is 9.0.1

 