### PR TITLE
Add missing XLATB group/import

### DIFF
--- a/codegen/x86_64.json
+++ b/codegen/x86_64.json
@@ -5,6 +5,7 @@
         "NOT", "NEG", "INC", "DEC",
         "TEST", "CMP",
         "MOV", "MOVZX", "MOVSX", "MOVSXD", "MOVBE", "MOVNTI",
+        "XLATB",
         "BT", "BTS", "BTR", "BTC", "POPCNT", "BSWAP",
         "BSF", "BSR", "LZCNT", "TZCNT",
         "SHR", "SAR", "SHL", "SAL", "SHRX", "SARX", "SHLX",

--- a/peachpy/x86_64/__init__.py
+++ b/peachpy/x86_64/__init__.py
@@ -36,6 +36,7 @@ from peachpy.x86_64.generic import \
     NOT, NEG, INC, DEC, \
     TEST, CMP, \
     MOV, MOVZX, MOVSX, MOVSXD, MOVBE, MOVNTI, \
+    XLATB, \
     BT, BTS, BTR, BTC, POPCNT, BSWAP, \
     BSF, BSR, LZCNT, TZCNT, \
     SHR, SAR, SHL, SAL, SHRX, SARX, SHLX, \


### PR DESCRIPTION
Have you thought about dropping x86_64.json (i.e. dump everything into a single file) and using import *? It took me a while to understand why newly added instructions (opcodes) did not generate classes until I closely looked at the codegen.