### PR TITLE
fix macho vmsize

### DIFF
--- a/peachpy/formats/macho/section.py
+++ b/peachpy/formats/macho/section.py
@@ -36,7 +36,7 @@ class Segment:
         assert isinstance(encoder, peachpy.encoder.Encoder)
 
         offset = section_offset_map[self.sections[0]]
-        memory_size = sum(section.content_size for section in self.sections)
+        memory_size = section_address_map[self.sections[-1]] + self.sections[-1].content_size
         file_size = sum(section.content_size for section in self.sections)
 
         address = 0


### PR DESCRIPTION
On mac, the current macho code does not set a valid VmSize on the segement. nm and objdump both complain with message like that, and in some instances stop dumping the file symbols.

```
lib/libnnpack.a(relu.py.o):
0000000000000060 T _nnp_grad_relu__avx2
0000000000000030 T _nnp_inplace_relu__avx2
0000000000000000 T _nnp_relu__avx2
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/nm: lib/libnnpack.a(softmax.py.o) truncated or malformed object (addr field plus size of section 1 in LC_SEGMENT_64 command 0 greater than than the segment's vmaddr plus vmsize)
```

I have no strong evidence of this breaking anything more than the bintools, but better safe...