### PR TITLE
Support for FreeBSD

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ PeachPy aims to simplify writing optimized assembly kernels while preserving all
 - Automatic adaption of function to different calling conventions and ABIs.
   
   * Functions for different platforms can be generated from the same assembly source
-  * Supports Microsoft x64 ABI, System V x86-64 ABI (Linux and OS X), Linux x32 ABI, Native Client x86-64 SFI ABI, Golang AMD64 ABI, Golang AMD64p32 ABI
+  * Supports Microsoft x64 ABI, System V x86-64 ABI (Linux, OS X, and FreeBSD), Linux x32 ABI, Native Client x86-64 SFI ABI, Golang AMD64 ABI, Golang AMD64p32 ABI
       
 - Automatic register allocation.
   

--- a/peachpy/loader.py
+++ b/peachpy/loader.py
@@ -26,11 +26,13 @@ class Loader:
         self._release_memory = None
 
         osname = sys.platform.lower()
-        if osname == "darwin" or osname.startswith("linux"):
+        if osname == "darwin" or osname.startswith("linux") or osname.startswith("freebsd"):
             import ctypes
 
             if osname == "darwin":
                 libc = ctypes.cdll.LoadLibrary("libc.dylib")
+            elif osname.startswith("freebsd"):
+                libc = ctypes.cdll.LoadLibrary("libc.so.7")
             else:
                 libc = ctypes.cdll.LoadLibrary("libc.so.6")
 

--- a/peachpy/x86_64/abi.py
+++ b/peachpy/x86_64/abi.py
@@ -135,6 +135,8 @@ def detect(system_abi=False):
     pointer_size = struct.calcsize("P")
     if osname == "Darwin" and machine == "x86_64" and (system_abi or pointer_size == 8):
         return system_v_x86_64_abi
+    elif osname == "FreeBSD" and machine == "amd64" and (system_abi or pointer_size == 8):
+        return system_v_x86_64_abi
     elif osname == "Linux" and machine == "x86_64":
         if system_abi or pointer_size == 8:
             return system_v_x86_64_abi

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "Operating System :: OS Independent",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",
+        "Operating System :: POSIX :: FreeBSD",
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Assembly",
         "Programming Language :: Python",


### PR DESCRIPTION
With this (surprisingly minimal!) change, all tests pass on my local machine (FreeBSD 11.3, amd64 processor). If you'd like, I can also add a CI configuration file for Cirrus CI, which supports FreeBSD.