### PR TITLE
A couple more fixes for FreeBSD

### DIFF
--- a/peachpy/formats/elf/file.py
+++ b/peachpy/formats/elf/file.py
@@ -86,6 +86,8 @@ class OSABI(IntEnum):
     none = 0
     # GNU Linux
     gnu = 3
+    # FreeBSD
+    freebsd = 9
     # ATI/AMD GPU ABI
     cal = 100
 

--- a/peachpy/x86_64/__main__.py
+++ b/peachpy/x86_64/__main__.py
@@ -152,7 +152,7 @@ def detect_native_image_format():
     osname = platform.system()
     if osname == "Darwin":
         return "mach-o"
-    elif osname == "Linux" or osname == "NaCl":
+    elif osname in ["Linux", "NaCl", "FreeBSD"]:
         return "elf"
     elif osname == "Windows":
         return "ms-coff"
@@ -164,6 +164,8 @@ def add_module_files(module_files, module, roots):
         return
 
     module_file = module.__file__
+    if module_file is None:
+        return
 
     import os
     if not any(module_file.startswith(root + os.sep) for root in roots):


### PR DESCRIPTION
This includes FreeBSD in the recognized ELF OSABI values, recognizes the native image format on FreeBSD as ELF, and skips adding module files when the `__file__` attribute is `None`.

Noticed while working on FreeBSD support in NNPACK.