### PR TITLE
Bump Python 3 versions on CI to 3.6 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
+  - "3.6"
+  - "3.7"
   - "pypy"
   - "pypy3"
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ version: 0.2.0.{build}
 environment:
   matrix:
   - PYTHON: C:\Python27-x64
-  - PYTHON: C:\Python33-x64
-  - PYTHON: C:\Python34-x64
+  - PYTHON: C:\Python36-x64
+  - PYTHON: C:\Python37-x64
 install:
 - '"%PYTHON%\Scripts\pip" install -r test\requirements.txt'
 build_script:


### PR DESCRIPTION
Both Travis and AppVeyor seem to be having issues with older versions of Python 3.