### PR TITLE
Allow asm printing for CALL(RIPRelativeOffset(3))

### DIFF
--- a/peachpy/x86_64/operand.py
+++ b/peachpy/x86_64/operand.py
@@ -428,10 +428,12 @@ class RIPRelativeOffset:
         return RIPRelativeOffset(self.offset - extra_offset)
 
     def format(self, assembly_format):
-        if self.offset > 0:
-            return "+%d" % self.offset
+        if assembly_format == "gas":
+            return "%d(%%rip)" % self.offset
+        elif assembly_format == "go":
+            return "%d(IP)" % self.offset
         else:
-            return "%d" % self.offset
+            return "rip%+d" % self.offset
 
 
 def is_al(operand):

--- a/peachpy/x86_64/operand.py
+++ b/peachpy/x86_64/operand.py
@@ -428,7 +428,7 @@ class RIPRelativeOffset:
         return RIPRelativeOffset(self.offset - extra_offset)
 
     def __str__(self):
-        return self.format("nasm")
+        return self.format("peachpy")
 
     def format(self, assembly_format):
         if assembly_format == "gas":

--- a/peachpy/x86_64/operand.py
+++ b/peachpy/x86_64/operand.py
@@ -427,6 +427,12 @@ class RIPRelativeOffset:
     def __sub__(self, extra_offset):
         return RIPRelativeOffset(self.offset - extra_offset)
 
+    def format(self, assembly_format):
+        if self.offset > 0:
+            return "+%d" % self.offset
+        else:
+            return "%d" % self.offset
+
 
 def is_al(operand):
     from peachpy.x86_64.registers import GeneralPurposeRegister8, al

--- a/peachpy/x86_64/operand.py
+++ b/peachpy/x86_64/operand.py
@@ -427,6 +427,9 @@ class RIPRelativeOffset:
     def __sub__(self, extra_offset):
         return RIPRelativeOffset(self.offset - extra_offset)
 
+    def __str__(self):
+        return self.format("nasm")
+
     def format(self, assembly_format):
         if assembly_format == "gas":
             return "%d(%%rip)" % self.offset


### PR DESCRIPTION
Without this PR, you get an error:
```
Traceback (most recent call last):
  File "gen.py", line 40, in <module>
    print_fn(fn)
  File "gen.py", line 26, in print_fn
    line = "\t%s%s# %s" % (i.encode().hex(" "), tabs, i.format("gas"))
  File "/home/certik/miniconda3/envs/asm/lib/python3.8/site-packages/peachpy/x86_64/instructions.py", line 79, in format
    return text + self.gas_name + " " + ", ".join(format_operand(op, assembly_format) for op in reversed(self.operands))
  File "/home/certik/miniconda3/envs/asm/lib/python3.8/site-packages/peachpy/x86_64/instructions.py", line 79, in <genexpr>
    return text + self.gas_name + " " + ", ".join(format_operand(op, assembly_format) for op in reversed(self.operands))
  File "/home/certik/miniconda3/envs/asm/lib/python3.8/site-packages/peachpy/x86_64/operand.py", line 81, in format_operand
    return operand.format(assembly_format)
AttributeError: 'RIPRelativeOffset' object has no attribute 'format'
```
with this PR, the Python code:
```python
    CALL(RIPRelativeOffset(3))
```
prints the following assembly:
```
call +3
```
and the following machine code:
```
e8 03 00 00 00
```