### PR TITLE
Added simple RIP CALL creation

### DIFF
--- a/peachpy/x86_64/operand.py
+++ b/peachpy/x86_64/operand.py
@@ -248,7 +248,7 @@ class MemoryOperand:
             isinstance(address, MaskedRegister) and \
             isinstance(address.register, (XMMRegister, YMMRegister, ZMMRegister)) and \
             not address.mask.is_zeroing, \
-            "Only MemoryAddress, 64-bit general-purpose registers, RIP Relative Offsets, XMM/YMM/ZMM registers, " \
+            "Only MemoryAddress, 64-bit general-purpose registers, RIP-Relative addresses, XMM/YMM/ZMM registers, " \
             "and merge-masked XMM/YMM/ZMM registers may be specified as an address"
         from peachpy.util import is_int
         assert size is None or is_int(size) and int(size) in SizeSpecification._size_name_map, \

--- a/peachpy/x86_64/operand.py
+++ b/peachpy/x86_64/operand.py
@@ -244,11 +244,11 @@ class MemoryOperand:
         from peachpy.x86_64.function import LocalVariable
         from peachpy.literal import Constant
         assert isinstance(address, (GeneralPurposeRegister64, XMMRegister, YMMRegister, ZMMRegister,
-                                    MemoryAddress, Constant, LocalVariable)) or \
+                                    MemoryAddress, Constant, LocalVariable, RIPRelativeOffset)) or \
             isinstance(address, MaskedRegister) and \
             isinstance(address.register, (XMMRegister, YMMRegister, ZMMRegister)) and \
             not address.mask.is_zeroing, \
-            "Only MemoryAddress, 64-bit general-purpose registers, XMM/YMM/ZMM registers, " \
+            "Only MemoryAddress, 64-bit general-purpose registers, RIP Relative Offsets, XMM/YMM/ZMM registers, " \
             "and merge-masked XMM/YMM/ZMM registers may be specified as an address"
         from peachpy.util import is_int
         assert size is None or is_int(size) and int(size) in SizeSpecification._size_name_map, \
@@ -279,6 +279,8 @@ class MemoryOperand:
             self.address = MemoryAddress(rsp, displacement=address.offset)
             self.symbol = address
             self.size = address.size
+        elif isinstance(address, RIPRelativeOffset):
+            self.address = address
         else:
             # Convert register to memory address expression
             self.address = MemoryAddress(address)


### PR DESCRIPTION
Allows using the following syntax:
```
CALL([rip+0x8])
```

Currently this can be done via the unintuitive:
```
CALL(RIPRelativeOffset(8))
```

https://github.com/Maratyszcza/PeachPy/issues/106