### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/test/arm/test_arm.py
+++ b/test/arm/test_arm.py
@@ -34,4 +34,4 @@ class TestARM(unittest.TestCase):
 
             RETURN()
 
-        print add_function.assembly
+        print(add_function.assembly)


### PR DESCRIPTION
Old style `print` statements are Syntax Errors in Python 3 but `print()` function works as expected on both Python 2 & 3.