### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ Using PeachPy as a command-line tool
   # Everything inside the `with` statement is function body
   with Function("DotProduct", (x, y), float_,
     # Enable instructions up to SSE4.2
-    # PeachPy will report error if you accidentially use a newer instruction
+    # PeachPy will report error if you accidentally use a newer instruction
     target=uarch.default + isa.sse4_2):
   
     # Request two 64-bit general-purpose registers. No need to specify exact names.
@@ -227,7 +227,7 @@ Users
 
 - `ChaCha20 <https://git.schwanenlied.me/yawning/chacha20>`_ -- Go implementation of ChaCha20 cryptographic cipher.
 
-- `AEZ <https://git.schwanenlied.me/yawning/aez>`_ -- Go implemenetation of AEZ authenticated-encryption scheme.
+- `AEZ <https://git.schwanenlied.me/yawning/aez>`_ -- Go implementation of AEZ authenticated-encryption scheme.
 
 - `bp128 <https://github.com/robskie/bp128>`_ -- Go implementation of SIMD-BP128 integer encoding and decoding.
 

--- a/codegen/x86_64.py
+++ b/codegen/x86_64.py
@@ -432,7 +432,7 @@ def generate_encoding_lambda(encoding, operands, use_off_argument=False):
                 evex_args.append("op[%d].address" % operands.index(component.X))
                 if component.vvvv != 0:
                     assert component.vvvv is component.V
-                    # Component.V | Compnent.vvvv encode the operand
+                    # Component.V | Component.vvvv encode the operand
                     evex_args.append("op[%d].code" % operands.index(component.vvvv))
                 else:
                     assert component.V == 0 or isinstance(component.V, Operand) and component.V.is_memory

--- a/peachpy/arm/function.py
+++ b/peachpy/arm/function.py
@@ -598,7 +598,7 @@ class Function(object):
                                 else:
                                     constraints[register_id_list] = tuple(options)
                         else:
-                            raise RegisterAllocationError("Imposible virtual register combination in instruction %s"
+                            raise RegisterAllocationError("Impossible virtual register combination in instruction %s"
                                                           % instruction)
                     elif all(isinstance(register, SRegister) for register in register_list) and \
                             isinstance(instruction, VFPLoadStoreMultipleInstruction):
@@ -651,7 +651,7 @@ class Function(object):
                                     constraints[register_id_list] = tuple(options)
                         else:
                             raise RegisterAllocationError(
-                                "Imposible virtual register combination in instruction %s" % instruction)
+                                "Impossible virtual register combination in instruction %s" % instruction)
                     else:
                         assert False
         report_register_constraints = False

--- a/peachpy/literal.py
+++ b/peachpy/literal.py
@@ -17,7 +17,7 @@ class Constant:
         assert isinstance(size, six.integer_types), "Constant size must be an integer"
         assert size in Constant._supported_sizes, "Unsupported size %s: the only supported sizes are %s" \
             % (str(size), ", ".join(map(str, sorted(Constant._supported_sizes))))
-        assert isinstance(repeats, six.integer_types), "The number of contant repeats must be an integer"
+        assert isinstance(repeats, six.integer_types), "The number of constant repeats must be an integer"
         assert size % repeats == 0, "The number of constant repeats must divide constant size without remainder"
         assert isinstance(element_ctype, Type), "Element type must be an instance of peachpy.c.Type"
         assert element_ctype in Constant._supported_types, "The only supported types are %s" \

--- a/peachpy/x86_64/function.py
+++ b/peachpy/x86_64/function.py
@@ -719,11 +719,11 @@ class Function:
             if any(surplus_count < 0 for surplus_count in six.itervalues(live_registers)):
                 if instruction.source_file is not None and instruction.line_number is not None:
                     raise peachpy.RegisterAllocationError(
-                        "The number of live virtual registers exceeds physical constaints %s at %s:%d" %
+                        "The number of live virtual registers exceeds physical constraints %s at %s:%d" %
                             (str(instruction), instruction.source_file, instruction.line_number))
                 else:
                     raise peachpy.RegisterAllocationError(
-                        "The number of live virtual registers exceeds physical constaints %s" % str(instruction))
+                        "The number of live virtual registers exceeds physical constraints %s" % str(instruction))
 
     def _preallocate_registers(self):
         """Allocates registers that can be binded only to a single virtual register.
@@ -800,14 +800,14 @@ class Function:
             other_cl_registers = filter(operator.methodcaller("__ne__", cl_register), cl_binded_registers)
             conflicting_registers = self._conflicting_registers[1][cl_register]
             if any([other_register in conflicting_registers for other_register in other_cl_registers]):
-                raise RegisterAllocationError("Two conflicting virtual registers are requred to bind to cl")
+                raise RegisterAllocationError("Two conflicting virtual registers are required to bind to cl")
 
         # Check that xmm0-binded registers are not mutually conflicting
         for xmm0_register in xmm0_binded_registers:
             other_xmm0_registers = filter(operator.methodcaller("__ne__", xmm0_register), xmm0_binded_registers)
             conflicting_registers = self._conflicting_registers[3][xmm0_register]
             if any([other_register in conflicting_registers for other_register in other_xmm0_registers]):
-                raise RegisterAllocationError("Two conflicting virtual registers are requred to bind to xmm0")
+                raise RegisterAllocationError("Two conflicting virtual registers are required to bind to xmm0")
 
         # Commit register allocations
         for cl_register in cl_binded_registers:

--- a/peachpy/x86_64/nacl.py
+++ b/peachpy/x86_64/nacl.py
@@ -52,7 +52,7 @@ from peachpy.x86_64.operand import check_operand, format_operand_type, is_r32, i
 #       mov ...,%esp
 #       lea (%rsp,%rZP,1),%rsp
 #
-# - naclspadj $N,%rZP (sandboxed %esp/rsp restore from %rbp; incudes $N offset)
+# - naclspadj $N,%rZP (sandboxed %esp/rsp restore from %rbp; includes $N offset)
 #       lea N(%rbp),%esp
 #       add %rZP,%rsp
 #

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
-        "Programming Langauge :: Python :: 3",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",


### PR DESCRIPTION
[`codespell --ignore-words-list=fo,moderm,poped,registery,suble -w .`](https://pypi.org/project/codespell)

@timgates42 Your review, please.