### PR TITLE
Import setuptools before distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
+from setuptools import setup
+from setuptools.command.develop import develop
 import distutils.log
 from distutils.command.build import build
-from setuptools.command.develop import develop
 from distutils.cmd import Command
-from setuptools import setup
 
 def read_text_file(path):
     import os


### PR DESCRIPTION
setuptools 60 uses its own bundled version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

This change in setuptools is to prepare for Python 3.12, which will drop distutils.

Fixes: https://bugs.debian.org/1022480